### PR TITLE
Fix base url in header

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -4,7 +4,7 @@
       <div class="header-wrapper">
         <div class="title">
           <NavLink
-            :link="$site.base"
+            link="/"
             class="home-link"
           >{{ $site.title }}
           </NavLink>

--- a/components/MobileHeader.vue
+++ b/components/MobileHeader.vue
@@ -3,7 +3,7 @@
     <div class="mobile-header-bar">
       <div class="mobile-header-title">
         <NavLink
-          :link="$site.base"
+          link="/"
           class="mobile-home-link"
         >{{ $site.title }}
         </NavLink>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When the blog is placed in a sub-folder,  base url is already presented. So don't need to append the base url again, otherwise it will be duplicated.

For example, when place the blog inside another app's folder `blog`, we will set the `base.url` to `/blog/` in `.vuepress/config.js`. Thus, the header url will become `/blog/blog` which is incorrect.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
